### PR TITLE
Overhaul the generated HTML output (and more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Collection of D-Man drawings from around the world
 
 Please feel free to add more!
 
+[Simple automatatically generated listing](https://dlang-community.github.io/d-mans).
+
 ### International D-Man collection
 
 By [@meiz_sandwich](https://twitter.com/meiz_sandwich).
 
 License: can be used for any promotion of the D language.
-
-[Simple automatatically generated listing](https://dlang-community.github.io/d-mans).
 
 ## Other D-Man resources
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 # Site settings
 title: International D-man collection
-description: >
-  Collection of D-Man drawings from around the world
+description: Collection of D-Man drawings from around the world
 baseurl: "/d-mans"
 
 # Build settings

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,12 +6,12 @@
 
     <nav class="site-nav">
       <div class="trigger">
-        {% for my_page in site.pages %}
-          {% if my_page.title %}
+        {%- for my_page in site.pages -%}
+          {%- if my_page.title -%}
           |
           <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a>
-          {% endif %}
-        {% endfor %}
+          {%- endif -%}
+        {%- endfor -%}
       </div>
     </nav>
 

--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@ layout: default
 
   <h1 class="page-heading">Available collections</h1>
 
-  <p>Please select a collection. </p>
+  <p>Please select a collection to view. </p>
 
   <ul>
-	  <li><a href="./meiz">Meiz</a></li>
+	  <li><a href="./meiz/">Meiz</a></li>
   </ul>
 
 </div>

--- a/meiz/index.html
+++ b/meiz/index.html
@@ -3,11 +3,11 @@ layout: default
 title: Meiz
 ---
 
-{% for file in site.static_files %}
-  {% assign pageurl = page.url | replace: 'index.html', '' %}
-  {% if file.path contains pageurl %}
-    {% if file.extname == '.jpg' %}
-	<img src="{{ site.baseurl }}/{{ file.path }}" style="max-width:30%" />
-    {% endif %}
-  {% endif %}
-{% endfor %}
+{% for file in site.static_files -%}
+  {%- assign pageurl = page.url | replace: 'index.html', '' -%}
+  {%- if file.path contains pageurl -%}
+    {%- if file.extname == '.jpg' %}
+      <img src="{{ site.baseurl }}/{{ file.path }}" alt="{{ file.basename }}" style="max-width:30%">
+    {%- endif -%}
+  {%- endif -%}
+{% endfor -%}

--- a/meiz/index.html
+++ b/meiz/index.html
@@ -7,7 +7,7 @@ title: Meiz
   {%- assign pageurl = page.url | replace: 'index.html', '' -%}
   {%- if file.path contains pageurl -%}
     {%- if file.extname == '.jpg' %}
-      <img src="{{ site.baseurl }}/{{ file.path }}" alt="{{ file.basename }}" style="max-width:30%">
+      <img src="{{ site.baseurl }}{{ file.path }}" alt="{{ file.basename }}" style="max-width:30%">
     {%- endif -%}
   {%- endif -%}
 {% endfor -%}


### PR DESCRIPTION
Fixes a few nits that nobody would bother to pick.

- Primarily removes the new-line spam.
- Adds an `alt` attribute to images using the filename (not exactly useful for the Meiz collection, but imho better than nothing).
- The placement of the link in the readme makes no sense when there are further collections added.